### PR TITLE
Fix for incorrect back button title.

### DIFF
--- a/Drip/Screens/Settings/Classes/SettingsView.swift
+++ b/Drip/Screens/Settings/Classes/SettingsView.swift
@@ -30,6 +30,7 @@ final class SettingsView: UIViewController, SettingsViewProtocol, PersistentData
 
     override func viewDidAppear(_ animated: Bool) {
         presenter.onViewDidAppear()
+        navigationItem.backBarButtonItem = nil
     }
 
     func presentView(_ view: UIViewController) {
@@ -41,7 +42,7 @@ final class SettingsView: UIViewController, SettingsViewProtocol, PersistentData
     }
 
     func pushView(_ view: UIViewController) {
-        self.navigationController!.pushViewController(view, animated: true)
+        self.navigationController?.pushViewController(view, animated: true)
     }
 
     func updateTitle(title: String) {


### PR DESCRIPTION
Now clears back bar button item on settings view appear to stop every pushed view having "save" as back button title. No longer uses a banged nav controller for safety in push view